### PR TITLE
QueryEscape added for user and password parameters

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -13,6 +13,5 @@ cpi_mkisofs/smake-1.2.4.tar.bz2:
   size: 426050
 golang_1.6/go1.6.linux-amd64.tar.gz:
   object_id: c6efe75b-9fe5-44a7-ae0b-2db46252b1de
-  sha: !binary |-
-    MDFhNmEyOGRiZTMxYTUzMTAzYjYwMDk3OWJiYmJkNjNhODEwNDQ1Ng==
+  sha: 01a6a28dbe31a53103b600979bbbbd63a8104456
   size: 84799480

--- a/src/github.com/vmware/photon-controller-go-sdk/photon/lightwave/oidcclient.go
+++ b/src/github.com/vmware/photon-controller-go-sdk/photon/lightwave/oidcclient.go
@@ -178,6 +178,8 @@ func (client *OIDCClient) GetTokenByRefreshTokenGrant(refreshToken string) (toke
 }
 
 func (client *OIDCClient) getToken(body string) (tokens *OIDCTokenResponse, err error) {
+	fmt.Println("Url: %s", client.buildUrl(tokenPath))
+	fmt.Println("Body: %s", body)
 	request, err := http.NewRequest("POST", client.buildUrl(tokenPath), strings.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/src/github.com/vmware/photon-controller-go-sdk/photon/lightwave/oidcclient.go
+++ b/src/github.com/vmware/photon-controller-go-sdk/photon/lightwave/oidcclient.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -168,6 +169,8 @@ type OIDCTokenResponse struct {
 }
 
 func (client *OIDCClient) GetTokenByPasswordGrant(username string, password string) (tokens *OIDCTokenResponse, err error) {
+	username = url.QueryEscape(username)
+	password = url.QueryEscape(password)
 	body := fmt.Sprintf(passwordGrantFormatString, username, password, client.Options.TokenScope)
 	return client.getToken(body)
 }
@@ -178,8 +181,6 @@ func (client *OIDCClient) GetTokenByRefreshTokenGrant(refreshToken string) (toke
 }
 
 func (client *OIDCClient) getToken(body string) (tokens *OIDCTokenResponse, err error) {
-	fmt.Println("Url: %s", client.buildUrl(tokenPath))
-	fmt.Println("Body: %s", body)
 	request, err := http.NewRequest("POST", client.buildUrl(tokenPath), strings.NewReader(body))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If my  photon password contains special symbols ('+' don't work for me) photon cpi crashes. This pull request fixes the issue.

That issue was already fixed in photon-go-sdk, but photon cpi-release just copies the source code of photon-cpi and photon go sdk. The proper way would be to include those repositories as sub-modules. 